### PR TITLE
Make local pub/sub blocks work with tests

### DIFF
--- a/local_publisher.py
+++ b/local_publisher.py
@@ -20,7 +20,7 @@ class LocalPublisher(PubSubConnectivity, TerminatorBlock):
     version = VersionProperty("1.1.0")
     topic = StringProperty(title='Topic', default="")
     local_identifier = StringProperty(
-        title='Local Identifier', default='[[INSTANCE_ID]]', visible=False)
+        title='Local Identifier', default='[[INSTANCE_ID]]', advanced=True)
 
     def __init__(self):
         super().__init__()
@@ -28,8 +28,11 @@ class LocalPublisher(PubSubConnectivity, TerminatorBlock):
 
     def configure(self, context):
         super().configure(context)
-        self._publisher = NioPublisher(
-            topic="{}.{}".format(self.local_identifier(), self.topic()))
+        topic = self.topic()
+        # If a local identifier was included use it as a prefix
+        if self.local_identifier():
+            topic = "{}.{}".format(self.local_identifier(), topic)
+        self._publisher = NioPublisher(topic=topic)
 
         try:
             self._publisher.open(on_connected=self.conn_on_connected,

--- a/local_subscriber.py
+++ b/local_subscriber.py
@@ -18,7 +18,7 @@ class LocalSubscriber(PubSubConnectivity, GeneratorBlock):
     version = VersionProperty("1.1.0")
     topic = StringProperty(title='Topic', default="")
     local_identifier = StringProperty(
-        title='Local Identifier', default='[[INSTANCE_ID]]', visible=False)
+        title='Local Identifier', default='[[INSTANCE_ID]]', advanced=True)
 
     def __init__(self):
         super().__init__()
@@ -26,9 +26,11 @@ class LocalSubscriber(PubSubConnectivity, GeneratorBlock):
 
     def configure(self, context):
         super().configure(context)
-        self._subscriber = NioSubscriber(
-            self._subscriber_handler,
-            topic="{}.{}".format(self.local_identifier(), self.topic()))
+        topic = self.topic()
+        # If a local identifier was included use it as a prefix
+        if self.local_identifier():
+            topic = "{}.{}".format(self.local_identifier(), topic)
+        self._subscriber = NioSubscriber(self._subscriber_handler, topic=topic)
 
         try:
             self._subscriber.open(on_connected=self.conn_on_connected,

--- a/local_subscriber.py
+++ b/local_subscriber.py
@@ -1,7 +1,7 @@
 from base64 import b64decode
 import pickle
 
-from nio import GeneratorBlock
+from nio import GeneratorBlock, Signal
 from nio.modules.communication.subscriber import Subscriber as NioSubscriber
 from nio.properties import StringProperty, VersionProperty
 
@@ -57,9 +57,21 @@ class LocalSubscriber(PubSubConnectivity, GeneratorBlock):
             signals = pickle.loads(signals)
         except pickle.UnpicklingError:
             self.logger.exception("Unpickling based pickle error")
+        except AttributeError:
+            # It's possible these came from a non-local publisher
+            # This would occur in service tests or if a regular publisher
+            # wanted to publish to a local topic. In the non-service test
+            # case this would generally indicate bad service design but we
+            # don't want to explicitly prevent/forbid it
+            if (signals and
+                    isinstance(signals, list) and
+                    isinstance(signals[0], Signal)):
+                self.notify_signals(signals)
+            else:
+                raise
         except TypeError:
             self.logger.exception("Unable to decode pickled signals")
-        except:
+        except Exception:
             self.logger.exception("Error handling signals")
         else:
             self.notify_signals(signals)

--- a/tests/test_local_pub_sub.py
+++ b/tests/test_local_pub_sub.py
@@ -71,3 +71,16 @@ class TestLocalPubSub(NIOBlockTestCase):
 
             subscriber.stop()
             communication.return_value.close.assert_called_once_with()
+
+    def test_no_local_id(self):
+        """ Make sure they can ignore the local id prefix if desired """
+        subscriber = Subscriber()
+        with patch(Subscriber.__module__ + '.NioSubscriber') as communication:
+            self.configure_block(
+                subscriber, {"topic": "topic", "local_identifier": ""})
+            communication.assert_called_once_with(ANY, topic="topic")
+        publisher = Publisher()
+        with patch(Publisher.__module__ + '.NioPublisher') as communication:
+            self.configure_block(
+                publisher, {"topic": "topic", "local_identifier": ""})
+            communication.assert_called_once_with(topic="topic")

--- a/tests/test_local_pub_sub.py
+++ b/tests/test_local_pub_sub.py
@@ -72,6 +72,31 @@ class TestLocalPubSub(NIOBlockTestCase):
             subscriber.stop()
             communication.return_value.close.assert_called_once_with()
 
+    def test_local_subscriber_nonlocal_publisher(self):
+        """ Ensure the LocalSubscriber can handle Publisher signals """
+        subscriber = Subscriber()
+
+        with patch(Subscriber.__module__ + '.NioSubscriber') as communication:
+            self.configure_block(
+                subscriber, {"topic": "topic", "local_identifier": "test"})
+            subscriber.start()
+
+        # call the subscriber handler with a raw list of signals, not the
+        # base64encoded signals that would come from the local publisher
+        communication.call_args[0][0](
+            [Signal({"key1": "val1"}), Signal({"key2": "val2"})])
+        self.assert_num_signals_notified(2)
+        self.assertDictEqual(
+            self.last_notified[DEFAULT_TERMINAL][0].to_dict(),
+            {"key1": "val1"}
+        )
+        self.assertDictEqual(
+            self.last_notified[DEFAULT_TERMINAL][1].to_dict(),
+            {"key2": "val2"}
+        )
+        subscriber.stop()
+
+
     def test_no_local_id(self):
         """ Make sure they can ignore the local id prefix if desired """
         subscriber = Subscriber()


### PR DESCRIPTION
This PR does three things:
 1. It makes the local identifier of the pub/sub blocks advanced, rather than invisible. Invisible properties are probably pretty rare and should be avoided with the introduction of advanced properties.
 2. It makes the local identifier (i.e., prefix) optional. If omitted, no local identifier will be prepended to the topic the publisher or subscriber use. This could be useful for more flexible service design and also allows us to override the local identifier in service tests so that the test writer doesn't have to know what a local prefix is.
 3. It allows straight lists of signals to be processed in the LocalSubscriber - these could come from the service tests or a regular Publisher block that published to the topic a LocalSubscriber block was subscribed to