### PR TITLE
Support local publishing in DynamicPublisher

### DIFF
--- a/docs/dynamic_publisher.md
+++ b/docs/dynamic_publisher.md
@@ -6,12 +6,14 @@ For more information on publishing to topics, view the [pub/sub docs.](https://d
 
 Properties
 ----------
-- **topic**: Hierarchical topic expression to publish the incoming signals to. 
+- **Topic**: Hierarchical topic expression to publish the incoming signals to. 
 
 Advanced Properties
 ---
 
-- **ttl**: Time-to-live for each published **topic**. If no signals have been received for this **topic** within the **ttl** window, then the Publisher is eligible for removal/garbage-collection.
+- **Time-to-live**: Time-to-live for each published **topic**. If no signals have been received for this **topic** within the **ttl** window, then the Publisher is eligible for removal/garbage-collection.
+- **Local Publisher?**: Configure this DynamicPublisher to act like a LocalPublisher block—can send data to the LocalSubscriber blocks on the same instance.
+- **Local Identifier**: Override the local identifier for local publishers. This value is only applicable when **Local Publisher?** is enabled.
 
   Note: If the *Time-to-live* is a negative value, then the published topics will *never* expire.
 
@@ -84,4 +86,4 @@ topic: "queues.process.{{ random.randint(1,4) }}"
 Notes
 ---
 
-If your topic is static then consider using the [Publisher](publisher.md) block instead.
+If your topic is static then consider using the [Publisher](publisher.md) or [LocalPublisher](local_publisher.md) blocks instead.

--- a/dynamic_publisher.py
+++ b/dynamic_publisher.py
@@ -35,7 +35,6 @@ class DynamicPublisher(PubSubConnectivity, TerminatorBlock):
         default=dict(seconds=600))
     is_local = BoolProperty(
         advanced=True,
-        allow_none=True,
         default=False,
         order=1,
         title="Local Publisher?")

--- a/dynamic_publisher.py
+++ b/dynamic_publisher.py
@@ -1,11 +1,13 @@
 from collections import defaultdict
 from threading import Lock
+from base64 import b64encode
+import pickle
 
-from nio import TerminatorBlock
+from nio import TerminatorBlock, Signal
 from nio.modules.communication.publisher import Publisher
 from nio.modules.communication.publisher import PublisherError
 from nio.modules.scheduler import Job
-from nio.properties import StringProperty, TimeDeltaProperty, VersionProperty
+from nio.properties import BoolProperty, StringProperty, TimeDeltaProperty, VersionProperty
 
 from .connectivity import PubSubConnectivity
 
@@ -23,18 +25,38 @@ class DynamicPublisher(PubSubConnectivity, TerminatorBlock):
     version = VersionProperty("0.1.0")
     topic = StringProperty(
         title="Topic",
-        default="")
+        default="",
+        order=0)
 
     ttl = TimeDeltaProperty(
         title="Time-to-live",
         advanced=True,
         order=0,
         default=dict(seconds=600))
+    is_local = BoolProperty(
+        advanced=True,
+        allow_none=True,
+        default=False,
+        order=1,
+        title="Local Publisher?")
+    local_identifier = StringProperty(
+        advanced=True,
+        default='[[INSTANCE_ID]]',
+        order=2,
+        title='Local Identifier')
 
     def __init__(self):
         super().__init__()
         self._cache = keydefaultdict(lambda topic: (self.__create_publisher(topic), None))
         self._cache_lock = Lock()
+        self._is_local = False
+        self._local_id = None
+
+    def configure(self, context):
+        super().configure(context)
+        self._is_local = self.is_local()
+        if self.is_local:
+            self._local_id = self.local_identifier()
 
     def stop(self):
         with self._cache_lock:
@@ -54,6 +76,8 @@ class DynamicPublisher(PubSubConnectivity, TerminatorBlock):
         for signal in in_signals:
             try:
                 topic = self.topic(signal)
+                if self._is_local and self._local_id:
+                    topic = '{}.{}'.format(self._local_id, topic)
             except Exception:
                 self.logger.exception('topic expression failed, ignoring signal')
                 continue
@@ -61,9 +85,18 @@ class DynamicPublisher(PubSubConnectivity, TerminatorBlock):
 
         for topic, out_signals in groups.items():
             try:
+                if self._is_local:
+                    out_signals = [Signal({"signals": b64encode(pickle.dumps(out_signals))})]
+
                 self.__get_publisher(topic, ttl).send(out_signals)
+            except pickle.PicklingError:
+                self.logger.exception("Pickling based pickle error")
+            except TypeError:
+                self.logger.exception("Unable to encode pickled signals")
             except PublisherError:  # pragma no cover
                 self.logger.exception('Error publishing {:n} signals to "{}"'.format(len(out_signals), topic))
+            except:
+                self.logger.exception("Error processing signals")
 
     def __close_publisher(self, topic):
         with self._cache_lock:

--- a/dynamic_publisher.py
+++ b/dynamic_publisher.py
@@ -54,7 +54,7 @@ class DynamicPublisher(PubSubConnectivity, TerminatorBlock):
     def configure(self, context):
         super().configure(context)
         self._is_local = self.is_local()
-        if self.is_local:
+        if self._is_local:
             self._local_id = self.local_identifier()
 
     def stop(self):

--- a/tests/test_dynamic_publisher_block.py
+++ b/tests/test_dynamic_publisher_block.py
@@ -21,7 +21,7 @@ class TestDynamicPublisher(NIOBlockTestCase):
         self.configure_block(publisher, {"topic": topic})
         publisher.start()
 
-        pub.assert_not_called()
+        self.assertEqual(pub.call_count, 0)
 
         signals = [Signal(dict(sig="foo"))]
         publisher.process_signals(signals)
@@ -41,7 +41,7 @@ class TestDynamicPublisher(NIOBlockTestCase):
         self.configure_block(publisher, {"topic": topic})
         publisher.start()
 
-        pub.assert_not_called()
+        self.assertEqual(pub.call_count, 0)
 
         signals = [Signal(dict(sig="foo"))]
         publisher.process_signals(signals)
@@ -70,7 +70,7 @@ class TestDynamicPublisher(NIOBlockTestCase):
         self.configure_block(publisher, {"topic": topic})
         publisher.start()
 
-        pub.assert_not_called()
+        self.assertEqual(pub.call_count, 0)
 
         signals = [Signal(dict(sig="foo", val=1))]
         publisher.process_signals(signals)
@@ -149,7 +149,7 @@ class TestDynamicPublisher(NIOBlockTestCase):
         block.start()
         block.process_signals([Signal(dict(sig="foo"))])
         pub.assert_called_once_with(topic="topic.foo")
-        pub.return_value.close.assert_not_called()
+        self.assertEqual(pub.return_value.close.call_count, 0)
 
         event.wait(.3)
 
@@ -167,14 +167,14 @@ class TestDynamicPublisher(NIOBlockTestCase):
         ))
 
         block.start()
-        publisher.assert_not_called()
+        self.assertEqual(publisher.call_count, 0)
         block.process_signals([Signal(dict(sig="foo"))])
 
         # should create the correct topic
         publisher.assert_called_once_with(topic="test.topic.foo")
 
         # should call send once
-        publisher.return_value.send.assert_called_once()
+        self.assertEqual(publisher.return_value.send.call_count, 1)
 
         # should be the correct format
         self.assertEqual(


### PR DESCRIPTION
needs tests and documentation but wanted to run this idea/implementation past people. This PR add a local publisher option to the DynamicPublisher block, which should be interoperable with the `LocalSubscriber` block.

If this looks like a good idea, then i'll update the tests and docs to cover—in local testing it works.