### PR TITLE
add support for never-expiring topics

### DIFF
--- a/docs/dynamic_publisher.md
+++ b/docs/dynamic_publisher.md
@@ -13,6 +13,8 @@ Advanced Properties
 
 - **ttl**: Time-to-live for each published **topic**. If no signals have been received for this **topic** within the **ttl** window, then the Publisher is eligible for removal/garbage-collection.
 
+  Note: If the *Time-to-live* is a negative value, then the published topics will *never* expire.
+
 Examples
 ---
 

--- a/tests/test_dynamic_publisher_block.py
+++ b/tests/test_dynamic_publisher_block.py
@@ -104,9 +104,9 @@ class TestDynamicPublisher(NIOBlockTestCase):
         pub.assert_any_call(topic="topic.bar")
         pub.assert_any_call(topic="topic.baz")
 
-        foo_pub, _ = block._cache.get("topic.foo", Mock())
-        bar_pub, _ = block._cache.get("topic.bar", Mock())
-        baz_pub, _ = block._cache.get("topic.baz", Mock())
+        foo_pub, _ = block._cache.get("topic.foo")
+        bar_pub, _ = block._cache.get("topic.bar")
+        baz_pub, _ = block._cache.get("topic.baz")
 
         foo_pub.send.assert_called_once_with([
             Signal(dict(sig="foo", val=1)),

--- a/tests/test_dynamic_publisher_block.py
+++ b/tests/test_dynamic_publisher_block.py
@@ -101,6 +101,7 @@ class TestDynamicPublisher(NIOBlockTestCase):
             ]
             block.process_signals(signals)
 
+            self.assertEqual(pub.call_count, 3)
             pub.assert_any_call(topic="topic.foo")
             pub.assert_any_call(topic="topic.bar")
             pub.assert_any_call(topic="topic.baz")

--- a/tests/test_dynamic_publisher_block.py
+++ b/tests/test_dynamic_publisher_block.py
@@ -105,23 +105,19 @@ class TestDynamicPublisher(NIOBlockTestCase):
             pub.assert_any_call(topic="topic.foo")
             pub.assert_any_call(topic="topic.bar")
             pub.assert_any_call(topic="topic.baz")
-
-            foo_pub = publishers.get("topic.foo")
-            bar_pub = publishers.get("topic.bar")
-            baz_pub = publishers.get("topic.baz")
-
-            foo_pub.send.assert_called_once_with([
+            
+            publishers.get("topic.foo").send.assert_called_once_with([
                 Signal(dict(sig="foo", val=1)),
                 Signal(dict(sig="foo", val=4)),
                 Signal(dict(sig="foo", val=6)),
             ])
 
-            bar_pub.send.assert_called_once_with([
+            publishers.get("topic.bar").send.assert_called_once_with([
                 Signal(dict(sig="bar", val=2)),
                 Signal(dict(sig="bar", val=5)),
             ])
 
-            baz_pub.send.assert_called_once_with([
+            publishers.get("topic.baz").send.assert_called_once_with([
                 Signal(dict(sig="baz", val=3)),
             ])
 

--- a/tests/test_dynamic_publisher_block.py
+++ b/tests/test_dynamic_publisher_block.py
@@ -151,7 +151,7 @@ class TestDynamicPublisher(NIOBlockTestCase):
 
             event.wait(.3)
 
-            pub.return_value.close.assert_called_once()
+            self.assertEqual(pub.return_value.close.call_count, 1)
 
     @patch(DynamicPublisher.__module__ + '.Publisher')
     def test_never_expiring(self, publisher):
@@ -164,11 +164,11 @@ class TestDynamicPublisher(NIOBlockTestCase):
         ))
 
         block.start()
-        publisher.assert_not_called()
+        self.assertEqual(publisher.call_count, 0)
         block.process_signals([Signal(dict(sig="foo"))])
 
         # should create the correct topic
         publisher.assert_called_once_with(topic="topic.foo")
 
         _, job = block._cache["topic.foo"]
-        self.assertEqual(job, None)
+        self.assertIsNone(job)

--- a/tests/test_dynamic_publisher_block.py
+++ b/tests/test_dynamic_publisher_block.py
@@ -86,8 +86,6 @@ class TestDynamicPublisher(NIOBlockTestCase):
     def test_partitioning(self):
         block = DynamicPublisher()
 
-        publishers = defaultdict(Mock)
-
         self.configure_block(block, {"topic": "topic.{{ $sig }}"})
         block.start()
 
@@ -100,6 +98,7 @@ class TestDynamicPublisher(NIOBlockTestCase):
             Signal(dict(sig="foo", val=6)),
         ]
 
+        publishers = defaultdict(Mock)
         with patch(DynamicPublisher.__module__ + '.Publisher', side_effect=lambda topic: publishers[topic]) as pub:
             block.process_signals(signals)
 


### PR DESCRIPTION
This PR adds support to the DynamicPublisher block to opt-into never expiring published topics with a negative TTL.